### PR TITLE
Add custom udfs for array filtering

### DIFF
--- a/solr/modules/sql/src/java/org/apache/solr/handler/sql/CalciteSolrDriver.java
+++ b/solr/modules/sql/src/java/org/apache/solr/handler/sql/CalciteSolrDriver.java
@@ -23,9 +23,12 @@ import org.apache.calcite.jdbc.CalciteConnection;
 import org.apache.calcite.jdbc.Driver;
 import org.apache.calcite.runtime.Hook;
 import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql2rel.SqlToRelConverter;
 import org.apache.calcite.util.Holder;
 import org.apache.solr.client.solrj.io.SolrClientCache;
+import org.apache.solr.handler.sql.functions.ArrayContainsAll;
+import org.apache.solr.handler.sql.functions.ArrayContainsAny;
 
 /**
  * JDBC driver for Calcite Solr.
@@ -87,9 +90,17 @@ public class CalciteSolrDriver extends Driver {
     final SolrSchema solrSchema = new SolrSchema(info, solrClientCache);
     rootSchema.add(schemaName, solrSchema);
 
+    registerUDFs();
+
     // Set the default schema
     calciteConnection.setSchema(schemaName);
     return calciteConnection;
+  }
+
+  private void registerUDFs() {
+    final SqlStdOperatorTable stdOpTab = SqlStdOperatorTable.instance();
+    stdOpTab.register(new ArrayContainsAll());
+    stdOpTab.register(new ArrayContainsAny());
   }
 
   public void setSolrClientCache(SolrClientCache solrClientCache) {

--- a/solr/modules/sql/src/java/org/apache/solr/handler/sql/functions/ArrayContains.java
+++ b/solr/modules/sql/src/java/org/apache/solr/handler/sql/functions/ArrayContains.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.solr.handler.sql.functions;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.sql.*;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlOperandCountRanges;
+import org.apache.calcite.sql.validate.SqlValidator;
+import org.apache.calcite.sql.validate.SqlValidatorScope;
+
+import java.util.Arrays;
+import java.util.List;
+
+public abstract class ArrayContains extends SqlFunction {
+
+  public ArrayContains(String name) {
+    super(name, SqlKind.OTHER_FUNCTION, ReturnTypes.BOOLEAN,
+        null, null, SqlFunctionCategory.USER_DEFINED_FUNCTION);
+  }
+
+  @Override
+  public SqlOperandCountRange getOperandCountRange() {
+    return SqlOperandCountRanges.of(2);
+  }
+
+  @Override
+  public boolean checkOperandTypes(SqlCallBinding callBinding,
+      boolean throwOnFailure) {
+    List<SqlNode> operands = callBinding.getCall().getOperandList();
+    SqlNode operand1 = operands.get(0);
+    SqlNode operand2 = operands.get(1);
+    if (operand1.getKind() == SqlKind.IDENTIFIER) {
+      if (operand2.getKind() == SqlKind.LITERAL) {
+        return true;
+      } else if (operand2.getKind() == SqlKind.ROW) {
+        SqlBasicCall valuesCall = (SqlBasicCall) operand2;
+        boolean literalMatch =Arrays.stream(valuesCall.getOperands()).allMatch(op -> op.getKind() == SqlKind.LITERAL);
+        if (literalMatch) {
+          return true;
+        }
+      }
+    }
+    if (throwOnFailure) {
+      throw callBinding.newValidationSignatureError();
+    } else {
+      return false;
+    }
+  }
+
+  @Override public RelDataType deriveType(SqlValidator validator,
+      SqlValidatorScope scope, SqlCall call) {
+    // To prevent operator rewriting by SqlFunction#deriveType.
+    for (SqlNode operand : call.getOperandList()) {
+      RelDataType nodeType = validator.deriveType(scope, operand);
+      validator.setValidatedNodeType(operand, nodeType);
+    }
+    return validateOperands(validator, scope, call);
+  }
+}

--- a/solr/modules/sql/src/java/org/apache/solr/handler/sql/functions/ArrayContainsAll.java
+++ b/solr/modules/sql/src/java/org/apache/solr/handler/sql/functions/ArrayContainsAll.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.solr.handler.sql.functions;
+
+/**
+ * Operator for filtering on Solr multi-valued fields with 'AND" clause.
+ * Example: ARRAY_CONTAINS_ALL(field, ('val1', 'val2')) will be transformed to
+ * filter query field:("val1" AND "val2")
+ */
+public class ArrayContainsAll extends ArrayContains {
+  private static final String UDF_NAME = "ARRAY_CONTAINS_ALL";
+
+  public ArrayContainsAll() {
+    super(UDF_NAME);
+  }
+
+  @Override
+  public String getAllowedSignatures(String opNameToUse) {
+    return "ARRAY_CONTAINS_ALL(IDENTIFIER, ('val1', 'val2'))";
+  }
+}

--- a/solr/modules/sql/src/java/org/apache/solr/handler/sql/functions/ArrayContainsAny.java
+++ b/solr/modules/sql/src/java/org/apache/solr/handler/sql/functions/ArrayContainsAny.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.solr.handler.sql.functions;
+
+/**
+ * Operator for filtering on Solr multi-valued fields with 'OR" clause.
+ * Example: ARRAY_CONTAINS_ALL(field, ('val1', 'val2')) will be transformed to
+ * filter query field:("val1" OR "val2")
+ */
+public class ArrayContainsAny extends ArrayContains {
+  private static final String UDF_NAME = "ARRAY_CONTAINS_ANY";
+
+  public ArrayContainsAny() {
+    super(UDF_NAME);
+  }
+
+  @Override
+  public String getAllowedSignatures(String opNameToUse) {
+    return "ARRAY_CONTAINS_ANY(IDENTIFIER, ('val1', 'val2'))";
+  }
+}

--- a/solr/modules/sql/src/test/org/apache/solr/handler/sql/TestSQLHandler.java
+++ b/solr/modules/sql/src/test/org/apache/solr/handler/sql/TestSQLHandler.java
@@ -2949,6 +2949,10 @@ public class TestSQLHandler extends SolrCloudTestCase {
     update.add("id", String.valueOf(maxDocs)); // all multi-valued fields are null
     update.commit(cluster.getSolrClient(), COLLECTIONORALIAS);
 
+    expectResults("SELECT longs, stringsx, booleans FROM $ALIAS WHERE longs = 2 AND longs = 4", 5);
+    expectResults("SELECT longs, pdoublexmv, booleans FROM $ALIAS WHERE pdoublexmv = 4.0 AND pdoublexmv = 5.0", 5);
+    expectResults("SELECT longs, pdoublexmv, booleans FROM $ALIAS WHERE pdoublexmv > 4.0", 5);
+    expectResults("SELECT stringxmv, stringsx, booleans FROM $ALIAS WHERE stringxmv = 'a' AND stringxmv = 'b' AND stringxmv = 'c'", 10);
     expectResults("SELECT stringxmv, stringsx, booleans FROM $ALIAS WHERE stringxmv > 'a'", 10);
     expectResults(
         "SELECT stringxmv, stringsx, booleans FROM $ALIAS WHERE stringxmv NOT IN ('a')", 1);
@@ -3184,5 +3188,36 @@ public class TestSQLHandler extends SolrCloudTestCase {
     expectResults(
         "SELECT COUNT(*) as QUERY_COUNT FROM $ALIAS WHERE (d_s='x') AND (id='1') AND (b_s='foo') HAVING COUNT(*) > 0",
         1);
+  }
+
+  @Test
+  public void testCustomUDFArrayContains() throws Exception {
+    new UpdateRequest()
+        .add("id", "1", "name_s", "hello-1", "a_i", "1", "stringxmv", "a", "stringxmv", "b",
+            "stringxmv", "c", "pdoublexmv", "1.5", "pdoublexmv", "2.5", "longs", "1", "longs", "2")
+        .add("id", "2", "name_s", "hello-2", "a_i", "2", "stringxmv", "c", "stringxmv", "d",
+            "stringxmv", "e", "pdoublexmv", "1.5", "pdoublexmv", "3.5", "longs", "1", "longs", "3")
+        .add("id", "3", "name_s", "hello-3", "a_i", "3", "stringxmv", "e", "stringxmv", "f",
+            "stringxmv", "a", "pdoublexmv", "2.5", "pdoublexmv", "3.5", "longs", "2", "longs", "3")
+
+        .commit(cluster.getSolrClient(), COLLECTIONORALIAS);
+
+    expectResults("select id, pdoublexmv from $ALIAS", 3);
+    expectResults("select id, stringxmv from $ALIAS WHERE array_contains_all(pdoublexmv, (1.5, 2.5))", 1);
+    expectResults("select id, stringxmv from $ALIAS WHERE array_contains_all(longs, (1, 3))", 1);
+    expectResults("select id, stringxmv from $ALIAS WHERE array_contains_all(stringxmv, 'c')", 2);
+    expectResults("select id, stringxmv from $ALIAS WHERE array_contains_all(stringxmv, ('c'))", 2);
+    expectResults("select id, stringxmv from $ALIAS WHERE array_contains_all(stringxmv, ('a', 'b', 'c'))", 1);
+    expectResults("select id, stringxmv from $ALIAS WHERE array_contains_all(stringxmv, ('b', 'c'))", 1);
+    expectResults("select id, stringxmv from $ALIAS WHERE array_contains_all(stringxmv, ('c', 'e'))", 1);
+    expectResults("select id, stringxmv from $ALIAS WHERE array_contains_all(stringxmv, ('c', 'd', 'e'))", 1);
+
+    expectResults("select id, stringxmv from $ALIAS WHERE array_contains_any(pdoublexmv, (1.5, 2.5))", 3);
+    expectResults("select id, stringxmv from $ALIAS WHERE array_contains_any(longs, (1, 3))", 3);
+    expectResults("select id, stringxmv from $ALIAS WHERE array_contains_any(stringxmv, ('a'))", 2);
+    expectResults("select id, stringxmv from $ALIAS WHERE array_contains_any(stringxmv, ('a', 'b', 'c'))", 3);
+    expectResults("select id, stringxmv from $ALIAS WHERE array_contains_any(stringxmv, ('a', 'c'))", 3);
+    expectResults("select id, stringxmv from $ALIAS WHERE array_contains_any(stringxmv, ('a', 'e'))", 3);
+    expectResults("select id, stringxmv from $ALIAS WHERE array_contains_any(stringxmv, ('a', 'e', 'f'))", 3);
   }
 }


### PR DESCRIPTION
*   Since Solr supports multi-valued fields, it would be crucial for Solr SQL to provide support for users to filter multi-valued fields via SQL
*   Support syntax like WHERE mv_field = 'a' and mv_field = 'b' would not make sense using SQL but we can support this via custom udfs
*   Add new udfs array_contains_all and array_contains_any to filter inside multi-valued fields as this provides a clean interface to use and no need to mess with the calcite rules
* Tests added
* Fixed bug with filtering on fields with doubles