### PR TITLE
SOLR-16199 Switch operand logic

### DIFF
--- a/solr/modules/sql/src/java/org/apache/solr/handler/sql/SolrFilter.java
+++ b/solr/modules/sql/src/java/org/apache/solr/handler/sql/SolrFilter.java
@@ -539,7 +539,7 @@ class SolrFilter extends Filter implements SolrRel {
           }
         }
         return Pair.of(
-                translateBinary2(call.getOperands().get(0), call.getOperands().get(1)), escapeChar);
+            translateBinary2(call.getOperands().get(0), call.getOperands().get(1)), escapeChar);
       } else {
         return Pair.of(getFieldValuePair(node), null);
       }

--- a/solr/modules/sql/src/java/org/apache/solr/handler/sql/SolrFilter.java
+++ b/solr/modules/sql/src/java/org/apache/solr/handler/sql/SolrFilter.java
@@ -373,7 +373,7 @@ class SolrFilter extends Filter implements SolrRel {
     private String translateLikeTermToSolrSyntax(String term, Character escapeChar) {
       boolean isEscaped = false;
       StringBuilder sb = new StringBuilder();
-      for (int i = 0; i < term.length() - 1; i++) {
+      for (int i = 0; i < term.length(); i++) {
         char c = term.charAt(i);
         // Only replace special characters if they are not escaped
         if (escapeChar != null && c == escapeChar) {

--- a/solr/modules/sql/src/java/org/apache/solr/handler/sql/SolrFilter.java
+++ b/solr/modules/sql/src/java/org/apache/solr/handler/sql/SolrFilter.java
@@ -22,7 +22,6 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.apache.calcite.plan.RelOptCluster;

--- a/solr/modules/sql/src/java/org/apache/solr/handler/sql/SolrFilter.java
+++ b/solr/modules/sql/src/java/org/apache/solr/handler/sql/SolrFilter.java
@@ -529,9 +529,7 @@ class SolrFilter extends Filter implements SolrRel {
         throw new AssertionError("expected RexCall for predicate but found: " + node);
       }
       RexCall call = (RexCall) node;
-      if (call.getOperands().size() == 2) {
-        return Pair.of(getFieldValuePair(node), null);
-      } else {
+      if (call.getOperands().size() == 3) {
         RexNode escapeNode = call.getOperands().get(2);
         Character escapeChar = null;
         if (escapeNode.getKind() == SqlKind.LITERAL) {
@@ -541,7 +539,9 @@ class SolrFilter extends Filter implements SolrRel {
           }
         }
         return Pair.of(
-            translateBinary2(call.getOperands().get(0), call.getOperands().get(1)), escapeChar);
+                translateBinary2(call.getOperands().get(0), call.getOperands().get(1)), escapeChar);
+      } else {
+        return Pair.of(getFieldValuePair(node), null);
       }
     }
 

--- a/solr/modules/sql/src/java/org/apache/solr/handler/sql/SolrFilter.java
+++ b/solr/modules/sql/src/java/org/apache/solr/handler/sql/SolrFilter.java
@@ -22,6 +22,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.apache.calcite.plan.RelOptCluster;
@@ -346,9 +347,12 @@ class SolrFilter extends Filter implements SolrRel {
     }
 
     protected String translateLike(RexNode like) {
-      Pair<String, RexLiteral> pair = getFieldValuePair(like);
+      Pair<Pair<String, RexLiteral>, Character> pairWithEscapeCharacter = getFieldValuePairWithEscapeCharacter(like);
+      Pair<String, RexLiteral> pair = pairWithEscapeCharacter.getKey();
+      Character escapeChar = pairWithEscapeCharacter.getValue();
+
       String terms = pair.getValue().toString().trim();
-      terms = terms.replace("'", "").replace('%', '*').replace('_', '?');
+      terms = translateLikeTermToSolrSyntax(terms, escapeChar);
 
       boolean hasMultipleTerms = false;
       if (!terms.startsWith("(") && !terms.startsWith("[") && !terms.startsWith("{")) {
@@ -366,6 +370,30 @@ class SolrFilter extends Filter implements SolrRel {
       }
 
       return pair.getKey() + ":" + terms;
+    }
+
+    private String translateLikeTermToSolrSyntax(String term, Character escapeChar) {
+      boolean isEscaped = false;
+      StringBuilder sb = new StringBuilder();
+      for (int i=0; i<term.length()-1; i++) {
+        char c = term.charAt(i);
+        // Only replace special characters if they are not escaped
+        if (escapeChar != null && c == escapeChar) {
+          isEscaped = true;
+        }
+        if (c == '%' && !isEscaped) {
+          sb.append('*');
+        } else if (c == '_' && !isEscaped) {
+          sb.append('?');
+        } else if (c == '\'' && isEscaped) {
+          sb.append('\'');
+          isEscaped = false;
+        } else if ((escapeChar ==null || escapeChar != c) && c != '\'') {
+          sb.append(c);
+          isEscaped = false;
+        }
+      }
+      return sb.toString();
     }
 
     protected String translateComparison(RexNode node) {
@@ -491,6 +519,26 @@ class SolrFilter extends Filter implements SolrRel {
         timestamp += "Z";
       }
       return timestamp;
+    }
+
+    protected Pair<Pair<String, RexLiteral>, Character> getFieldValuePairWithEscapeCharacter(RexNode node) {
+      if (!(node instanceof RexCall)) {
+        throw new AssertionError("expected RexCall for predicate but found: " + node);
+      }
+      RexCall call = (RexCall) node;
+      if (call.getOperands().size() == 2) {
+        return Pair.of(getFieldValuePair(node), null);
+      } else {
+        RexNode escapeNode = call.getOperands().get(2);
+        Character escapeChar = null;
+        if (escapeNode.getKind() == SqlKind.LITERAL) {
+          RexLiteral literal = (RexLiteral) escapeNode;
+          if (literal.getTypeName() == SqlTypeName.CHAR) {
+            escapeChar = literal.getValueAs(Character.class);
+          }
+        }
+        return Pair.of(translateBinary2(call.getOperands().get(0), call.getOperands().get(1)), escapeChar);
+      }
     }
 
     protected Pair<String, RexLiteral> getFieldValuePair(RexNode node) {

--- a/solr/modules/sql/src/test/org/apache/solr/handler/sql/TestSQLHandler.java
+++ b/solr/modules/sql/src/test/org/apache/solr/handler/sql/TestSQLHandler.java
@@ -2483,7 +2483,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
             "id",
             "6",
             "a_s",
-            "worlds-6",
+            "world-6",
             "b_s",
             "bar",
             "c_t",
@@ -2500,7 +2500,6 @@ public class TestSQLHandler extends SolrCloudTestCase {
         .commit(cluster.getSolrClient(), COLLECTIONORALIAS);
 
     expectResults("SELECT a_s FROM $ALIAS WHERE a_s LIKE 'h_llo-%'", 3);
-    expectResults("SELECT a_s FROM $ALIAS WHERE a_s LIKE 'world\\__' ESCAPE '\\'", 1);
     expectResults("SELECT a_s FROM $ALIAS WHERE a_s LIKE 'world\\%\\__' ESCAPE '\\'", 1);
 
     // not technically valid SQL but we support it for legacy purposes, see: SOLR-15463

--- a/solr/modules/sql/src/test/org/apache/solr/handler/sql/TestSQLHandler.java
+++ b/solr/modules/sql/src/test/org/apache/solr/handler/sql/TestSQLHandler.java
@@ -2483,7 +2483,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
             "id",
             "6",
             "a_s",
-            "world-6",
+            "w_orld-6",
             "b_s",
             "bar",
             "c_t",
@@ -2500,10 +2500,11 @@ public class TestSQLHandler extends SolrCloudTestCase {
         .commit(cluster.getSolrClient(), COLLECTIONORALIAS);
 
     expectResults("SELECT a_s FROM $ALIAS WHERE a_s LIKE 'h_llo-%'", 3);
+    expectResults("SELECT a_s FROM $ALIAS WHERE a_s LIKE 'w\\_o_ld%' ESCAPE '\\'", 1);
     expectResults("SELECT a_s FROM $ALIAS WHERE a_s LIKE 'world\\%\\__' ESCAPE '\\'", 1);
 
     // not technically valid SQL but we support it for legacy purposes, see: SOLR-15463
-    expectResults("SELECT a_s FROM $ALIAS WHERE a_s='world-*'", 3);
+    expectResults("SELECT a_s FROM $ALIAS WHERE a_s='world-*'", 2);
 
     // no results
     expectResults("SELECT a_s FROM $ALIAS WHERE a_s LIKE '%MATCHNONE%'", 0);

--- a/solr/modules/sql/src/test/org/apache/solr/handler/sql/TestSQLHandler.java
+++ b/solr/modules/sql/src/test/org/apache/solr/handler/sql/TestSQLHandler.java
@@ -2488,9 +2488,19 @@ public class TestSQLHandler extends SolrCloudTestCase {
             "bar",
             "c_t",
             "the sly black dog jumped over the sleepin piglet")
-        .commit(cluster.getSolrClient(), COLLECTIONORALIAS);
+        .add(
+            "id",
+            "7",
+            "a_s",
+            "world%_7",
+            "b_s",
+            "zaz",
+            "c_t",
+            "the lazy dog jumped over the quick brown fox")
+            .commit(cluster.getSolrClient(), COLLECTIONORALIAS);
 
     expectResults("SELECT a_s FROM $ALIAS WHERE a_s LIKE 'h_llo-%'", 3);
+    expectResults("SELECT a_s FROM $ALIAS WHERE a_s LIKE 'world\\%\\__' ESCAPE '\\'", 1);
 
     // not technically valid SQL but we support it for legacy purposes, see: SOLR-15463
     expectResults("SELECT a_s FROM $ALIAS WHERE a_s='world-*'", 3);
@@ -2502,7 +2512,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
     expectResults("SELECT b_s FROM $ALIAS WHERE b_s LIKE 'foo'", 5);
 
     // NOT LIKE
-    expectResults("SELECT b_s FROM $ALIAS WHERE b_s NOT LIKE 'f%'", 1);
+    expectResults("SELECT b_s FROM $ALIAS WHERE b_s NOT LIKE 'f%'", 2);
 
     // leading wildcard
     expectResults("SELECT b_s FROM $ALIAS WHERE b_s LIKE '%oo'", 5);
@@ -2512,19 +2522,19 @@ public class TestSQLHandler extends SolrCloudTestCase {
 
     expectResults("SELECT b_s FROM $ALIAS WHERE b_s LIKE '(ba*)'", 1);
 
-    expectResults("SELECT b_s FROM $ALIAS WHERE c_t LIKE 'fox'", 3);
+    expectResults("SELECT b_s FROM $ALIAS WHERE c_t LIKE 'fox'", 4);
     expectResults("SELECT b_s FROM $ALIAS WHERE c_t LIKE 'sleep% pig%'", 3);
     expectResults("SELECT b_s FROM $ALIAS WHERE c_t LIKE 'sleep% pigle%'", 1);
     expectResults("SELECT b_s FROM $ALIAS WHERE c_t LIKE 'sleep% piglet'", 1);
 
-    expectResults("SELECT b_s FROM $ALIAS WHERE c_t LIKE 'jump%'", 6);
-    expectResults("SELECT b_s FROM $ALIAS WHERE c_t LIKE '%ump%'", 6);
+    expectResults("SELECT b_s FROM $ALIAS WHERE c_t LIKE 'jump%'", 7);
+    expectResults("SELECT b_s FROM $ALIAS WHERE c_t LIKE '%ump%'", 7);
 
     expectResults("SELECT b_s FROM $ALIAS WHERE c_t LIKE '(\"dog pig\"~5)'", 2);
-    expectResults("SELECT b_s FROM $ALIAS WHERE c_t LIKE 'jumped over'", 6);
-    expectResults("SELECT b_s FROM $ALIAS WHERE c_t LIKE 'quick brown fox'", 3);
+    expectResults("SELECT b_s FROM $ALIAS WHERE c_t LIKE 'jumped over'", 7);
+    expectResults("SELECT b_s FROM $ALIAS WHERE c_t LIKE 'quick brown fox'", 4);
     expectResults("SELECT b_s FROM $ALIAS WHERE b_s LIKE 'foo*'", 5);
-    expectResults("SELECT b_s FROM $ALIAS WHERE c_t LIKE '*og'", 6);
+    expectResults("SELECT b_s FROM $ALIAS WHERE c_t LIKE '*og'", 7);
   }
 
   @Test

--- a/solr/modules/sql/src/test/org/apache/solr/handler/sql/TestSQLHandler.java
+++ b/solr/modules/sql/src/test/org/apache/solr/handler/sql/TestSQLHandler.java
@@ -2483,7 +2483,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
             "id",
             "6",
             "a_s",
-            "world-6",
+            "worlds-6",
             "b_s",
             "bar",
             "c_t",
@@ -2500,6 +2500,7 @@ public class TestSQLHandler extends SolrCloudTestCase {
         .commit(cluster.getSolrClient(), COLLECTIONORALIAS);
 
     expectResults("SELECT a_s FROM $ALIAS WHERE a_s LIKE 'h_llo-%'", 3);
+    expectResults("SELECT a_s FROM $ALIAS WHERE a_s LIKE 'world\\__' ESCAPE '\\'", 1);
     expectResults("SELECT a_s FROM $ALIAS WHERE a_s LIKE 'world\\%\\__' ESCAPE '\\'", 1);
 
     // not technically valid SQL but we support it for legacy purposes, see: SOLR-15463


### PR DESCRIPTION
# Description

Switch the conditional logic to parse out the escape character only if the number of operands are exactly 3
 
# Solution

Please provide a short description of the approach taken to implement your solution.

# Tests

Please describe the tests you've developed or run to confirm this patch implements the feature or solves the problem.

# Checklist

Please review the following and check all that apply:

- [ ] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [ ] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [ ] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
